### PR TITLE
Fixes regarding mouse events and status line display

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,28 @@ require('apm').setup()
 to your `init.lua`
 
 and call `:PackerInstall`
+
+With [Lazy](https://github.com/folke/lazy.nvim):
+
+```lua
+--- Lazy
+{
+    'pekikii/apm.nvim',
+    config = function()
+      require('apm').setup()
+    end,
+}
+```
+
+## Integration with statusline plugins like lualine
+
+```lua
+--- Inside lualine config
+    local apm = require('apm').get_apm_status
+    require('lualine').setup {
+    sections = {
+      lualine_y = { apm }
+    }
+}
+
+```

--- a/lua/apm/init.lua
+++ b/lua/apm/init.lua
@@ -48,7 +48,11 @@ function M.calculate_rolling_average()
     return string.format("%d", average)
 end
 
-function M.on_key_press()
+function M.on_key_press(key)
+    -- Ignore non-keyboard mouse inputs like mouse clicks and scrolls
+    if key:match("\x80\xfd") then
+        return
+    end
     local current_time = vim.loop.hrtime()
     table.insert(key_press_times, current_time)
 end
@@ -65,6 +69,10 @@ end
 function M.setup_statusline()
     local current_statusline = vim.o.statusline
     vim.o.statusline = current_statusline .. " APM:%{v:lua.require'apm'.calculate_rolling_average()} "
+end
+
+function M.get_apm_status()
+    return "APM: " .. M.calculate_rolling_average()
 end
 
 function M.setup()


### PR DESCRIPTION
- In current implementation mouse clicks and scrolls get calculated as a part of APM calculation. I have updated the on_key_press to ignore mouse events
- External statusline plugins currently override the apm displayed. Instead added a function get_apm_status that returns a string which can be configured into any statusline plugin.
- Updated Readme with instructions for setting up apm with any statusline plugin, and added install steps for Lazy as well